### PR TITLE
Dockerfile: use build_kit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM golang:1.18 as build
+FROM --platform=$BUILDPLATFORM golang:1.18 as build
+
 WORKDIR /apisprout
 
 COPY go.sum go.mod ./
 RUN go mod download
 
 COPY . .
-RUN go build ./cmd/apisprout
+
+ARG TARGETOS TARGETARCH
+
+RUN GOARCH=$TARGETARCH GOOS=$TARGETOS CGO_ENABLED=0 go build ./cmd/apisprout
 
 FROM gcr.io/distroless/base-debian11
 
 COPY --from=build /apisprout/apisprout /usr/local/bin/
-
-EXPOSE 8000
 
 ENTRYPOINT ["/usr/local/bin/apisprout"]


### PR DESCRIPTION
The multi arch build is much faster this way as we don't need to run command in a virtual machine/emulator.

Signed-off-by: leonnicolas <leonloechner@gmx.de>